### PR TITLE
Check 'end' and 'error' events in fromStream()

### DIFF
--- a/lib/from-stream-test.ts
+++ b/lib/from-stream-test.ts
@@ -6,16 +6,36 @@ describe('fromStream', () => {
   it('takes a stream and returns an async iterable', async () => {
     const stream = new PassThrough({ objectMode: true })
     stream.write(1)
-    stream.end()
-    for await (const value of fromStream(stream)) {
-      assert.equal(value, 1)
+    const actual: number[] = []
+    for await (const value of fromStream<number>(stream)) {
+      if (value === 1) {
+        setImmediate(() => {
+          stream.write(2)
+          stream.end()
+        })
+      }
+      actual.push(value)
     }
+    assert.deepEqual(actual, [1, 2])
   })
   it('iterates empty streams', async () => {
     const stream = new PassThrough({ objectMode: true })
     stream.end()
     for await (const value of fromStream(stream)) {
       throw new Error(`${value} shouldn't have been resolved`)
+    }
+  })
+  it('propagates errors', async () => {
+    const stream = new PassThrough({ objectMode: true })
+    stream.write(1)
+    const expected = new Error('')
+    try {
+      for await (const _ of fromStream(stream)) {
+        stream.emit('error', expected)
+      }
+      throw new Error('Iterator should have errored')
+    } catch (error) {
+      assert.equal(error, expected)
     }
   })
 })

--- a/lib/from-stream.ts
+++ b/lib/from-stream.ts
@@ -1,7 +1,7 @@
 /// <reference lib="esnext.asynciterable" />
 interface IReadable {
-  once: any
-  read: any
+  once(event: string, cb: (value: any) => void): any
+  read(): any
 }
 
 async function onceReadable(stream: IReadable) {


### PR DESCRIPTION
Remove access to private `_readableState`, which may be missing from third-party stream implementations.

Assumes non-ended streams are passed, in paused mode, in which case `end` is emitted after `read()` is called.

Fixes https://github.com/reconbot/streaming-iterables/issues/1.

I realize the commit messages are not in the expected format, but I reckon you can fix that in a squash merge 😉 