### PR TITLE
fix: parallelMap had one extra parallel execution then it should

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ function buffer<T>(size: number, iterable: Iterable<T>): AsyncIterable<T>
 ```
 Buffer keeps a number of objects in reserve available for immediate reading. This is helpful with async iterators as it will prefetch results so you don't have to wait for them to load. For sync iterables it will precompute up to `size` values and keep them in reserve. The internal buffer will start to be filled once `.next()` is called for the first time and will continue to fill until the source `iterable` is exhausted or the buffer is full. Errors from the source `iterable` will be raised after all buffered values are yielded.
 
-`size` can be betweeen 1 and `Infinity`.
+`size` can be between 0 and `Infinity`.
 
 ```ts
 import { buffer } from 'streaming-iterables'

--- a/lib/buffer-test.ts
+++ b/lib/buffer-test.ts
@@ -44,7 +44,6 @@ describe('buffer', () => {
     assert.equal(5, (await itr.next()).value)
     assert.equal(6, (await itr.next()).value)
   })
-
   it('is curryable', async () => {
     const itr = buffer(2)([1, 2, 3, 4, 5, 6])[Symbol.iterator]()
     assert.equal(1, (await itr.next()).value)
@@ -57,6 +56,13 @@ describe('buffer', () => {
   it('deals with an infinite size', async () => {
     const values: number[] = []
     for await (const value of buffer(Infinity, asyncFromArray([1, 2, 3, 4]))) {
+      values.push(value)
+    }
+    assert.deepEqual(values, [1, 2, 3, 4])
+  })
+  it('deals with an no size', async () => {
+    const values: number[] = []
+    for await (const value of buffer(0, asyncFromArray([1, 2, 3, 4]))) {
       values.push(value)
     }
     assert.deepEqual(values, [1, 2, 3, 4])

--- a/lib/buffer.ts
+++ b/lib/buffer.ts
@@ -117,6 +117,9 @@ export function buffer(size: number, iterable?: AnyIterable<any>): CurriedBuffer
   if (iterable === undefined) {
     return curriedIterable => buffer(size, curriedIterable)
   }
+  if (size === 0) {
+    return iterable
+  }
   if (iterable[Symbol.asyncIterator]) {
     return _buffer(size, iterable as AsyncIterable<any>)
   }

--- a/lib/parallel-flat-map-test.ts
+++ b/lib/parallel-flat-map-test.ts
@@ -57,7 +57,7 @@ describe('parallelFlatMap', () => {
     const itr = iterable[Symbol.asyncIterator]()
     await itr.next()
     await delayTicks(5)
-    await assert.equal(mapCount, 4)
+    await assert.equal(mapCount, 3)
   })
   it('can have a concurrency more than the items in a stream', async () => {
     const stream = new PassThrough()

--- a/lib/parallel-map.ts
+++ b/lib/parallel-map.ts
@@ -23,7 +23,7 @@ async function* _parallelMap<T, R>(
       yield value
     }
   }
-  const output = pipeline(() => iterable, buffer(1), stopOnError, map(wrapFunc), buffer(concurrency))
+  const output = pipeline(() => iterable, buffer(1), stopOnError, map(wrapFunc), buffer(concurrency - 1))
   const itr: AsyncIterator<{ value: Promise<R> | R }> = getIterator(output)
   while (true) {
     const { value, done } = await itr.next()
@@ -65,6 +65,9 @@ export function parallelMap<T, R>(concurrency: number, func?: (data: T) => R | P
   }
   if (iterable === undefined) {
     return curriedIterable => parallelMap(concurrency, func, curriedIterable)
+  }
+  if (concurrency === 1) {
+    return map(func, iterable)
   }
   return _parallelMap(concurrency, func, iterable)
 }


### PR DESCRIPTION
- parallelMap no longer runs one extra mapping function at a time then it should
- parallelMap can now run with a parallelism of 1 which would just uses map() as it’s faster
- buffer now takes 0 as an input which just returns the passed in iterable as it’s faster
- fixed a test of parallelFlatMap as it used parallelMap