### PR TITLE
chore: drop node 10 and 12 support as they're EOL

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,13 +1,13 @@
 name: Node CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [14.x, 16.x, 18.x]
     steps:
     - uses: actions/checkout@v1
     - name: Use Node.js ${{ matrix.node-version }}

--- a/README.md
+++ b/README.md
@@ -342,6 +342,7 @@ function fromStream<T>(stream: Readable): AsyncIterable<T>
 Wraps the stream in an async iterator or returns the stream if it already is an async iterator.
 
 *note*: Since Node 10, streams already async iterators. This function may be used to ensure compatibility with older versions of Node.
+*note*: This method is deprecated since, node 10 is out of LTS. It may be removed in an upcoming major release.
 
 ```ts
 import { fromStream } from 'streaming-iterables'

--- a/lib/from-stream.ts
+++ b/lib/from-stream.ts
@@ -40,6 +40,7 @@ for await (const pokeData of pokeLog) {
   console.log(pokeData) // Buffer(...)
 }
 ```
+ * @deprecated This method is deprecated since, node 10 is out of LTS. It may be removed in an upcoming major release.
  */
 export function fromStream<T>(stream: ReadableStreamish): AsyncIterable<T> {
   if (typeof stream[Symbol.asyncIterator] === 'function') {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "typescript": "^4.5.5"
   },
   "engines": {
-    "node": ">=10"
+    "node": ">=14"
   },
   "mocha": {
     "bail": true,


### PR DESCRIPTION
BREAKING CHANGE: we're dropping support for node versions