### PR TITLE
Add type information to `exports.*` in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,14 @@
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {
-    "require": "./dist/index.js",
-    "import": "./dist/index.mjs"
+    "require": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "import": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.mjs"
+    }
   },
   "types": "dist/index.d.ts",
   "repository": "git@github.com:reconbot/streaming-iterables.git",


### PR DESCRIPTION
This PR fixes an issue where typescript project using `node16` or `nodenext` module resolution fail to find types.

This results in the following error:

```sh
$ tsc
index.ts:1:37 - error TS7016: Could not find a declaration file for module 'streaming-iterables'. '/Users/bbera/code/oss/streaming-iterables/dist/index.mjs' implicitly has an 'any' type.
  There are types at '/Users/bbera/code/oss/streaming-iterables/__scratch/test-project/node_modules/streaming-iterables/dist/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'streaming-iterables' library may need to update its package.json or typings.

1 import * as streamingIterables from 'streaming-iterables'
                                      ~~~~~~~~~~~~~~~~~~~~~


Found 1 error in index.ts:1
```

This change is based on the following documentation: https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing

## Steps to reproduce

Create a test project with the following files:

`packages.json`:
```json
{
  "name": "test-project",
  "type": "module",
  "devDependencies": {
    "typescript": "^5.1.6"
  },
  "dependencies": {
    "streaming-iterables": "^7.1.0"
  }
}
```

`tsconfig.json`:
```json
{
  "compilerOptions": {
    "target": "es2016",
    "module": "Node16",
    "moduleResolution": "Node16",
    "esModuleInterop": true,
    "forceConsistentCasingInFileNames": true,
    "strict": true,
    "skipLibCheck": false
  }
}
```

`index.ts`:
```ts
import * as streamingIterables from 'streaming-iterables'
console.log(streamingIterables)
```

Then, run the following commands:

```sh
npm install
./node_modules/.bin/tsc
```